### PR TITLE
Bugfix/explicit cache control

### DIFF
--- a/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
+++ b/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
@@ -101,6 +101,9 @@ module.exports = async function () {
     };
     await file.save(JSON.stringify(output), {
       contentType: "application/json",
+      metadata: {
+        cacheControl: "public, max-age=10",
+      },
     });
   } catch (error) {
     console.error(error);

--- a/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
+++ b/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
@@ -60,11 +60,9 @@ function replace(event, eventProp, associations, kind) {
       but Artists have either "name" or "id" properties
       depending on when they were imported
     */
-    const keyProp = event[eventProp].hasOwnProperty("name") ? "name" : "id";
+    const keyProp = Object.hasOwn(event[eventProp], "name") ? "name" : "id";
     event[eventProp] = associations[kind].find(
-      (entity) => {        
-        return entity[datastore.KEY][keyProp] === event[eventProp][keyProp];
-      },
+      (entity) => entity[datastore.KEY][keyProp] === event[eventProp][keyProp],
     );
   }
 }
@@ -74,7 +72,7 @@ async function join(events, associations) {
     replace(event, "selector", associations, "User");
     replace(event, "album", associations, "Album");
     replace(event, "artist", associations, "Artist");
-    replace(event, "track", associations, "Track");    
+    replace(event, "track", associations, "Track");
 
     const [urlSafeKey] = await datastore.keyToLegacyUrlSafe(
       event[datastore.KEY],

--- a/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
+++ b/update-playlist-storage/lib/updatePlaylistStorageFromDatastore.js
@@ -52,20 +52,29 @@ async function getAssociatedEntities(events) {
   }, {});
 }
 
-function replace(event, eventProp, associations, kind, keyProp) {
+function replace(event, eventProp, associations, kind) {
   if (event[eventProp]) {
+    /* 
+      Albums and Tracks use "name" consistently
+      Users use "id" consistently
+      but Artists have either "name" or "id" properties
+      depending on when they were imported
+    */
+    const keyProp = event[eventProp].hasOwnProperty("name") ? "name" : "id";
     event[eventProp] = associations[kind].find(
-      (entity) => entity[datastore.KEY][keyProp] === event[eventProp][keyProp],
+      (entity) => {        
+        return entity[datastore.KEY][keyProp] === event[eventProp][keyProp];
+      },
     );
   }
 }
 
 async function join(events, associations) {
   for (const event of events) {
-    replace(event, "selector", associations, "User", "id");
-    replace(event, "album", associations, "Album", "name");
-    replace(event, "artist", associations, "Artist", "name");
-    replace(event, "track", associations, "Track", "name");
+    replace(event, "selector", associations, "User");
+    replace(event, "album", associations, "Album");
+    replace(event, "artist", associations, "Artist");
+    replace(event, "track", associations, "Track");    
 
     const [urlSafeKey] = await datastore.keyToLegacyUrlSafe(
       event[datastore.KEY],


### PR DESCRIPTION
- Adds cache control header so playlist.json caches for 10 seconds instead of the default of an hour
- Fixes an issue with joining the artist when that artist was part of the original Datastore import and uses a numerical `id` instead of an alphanumeric `name`